### PR TITLE
Convert msg to a byte string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,9 +81,13 @@ celerybeat-schedule
 # virtualenv
 venv/
 ENV/
+.venv/
 
 # Spyder project settings
 .spyderproject
 
 # Rope project settings
 .ropeproject
+
+# VS Code settings
+.vscode

--- a/SSRS/__init__.py
+++ b/SSRS/__init__.py
@@ -4,6 +4,7 @@ from suds.client import Client
 from suds.sax.text import Text
 from suds.sax.element import Element
 from suds.transport.http import HttpAuthenticated
+from suds import byte_str
 import requests
 from requests_ntlm import HttpNtlmAuth
 import suds_requests
@@ -247,6 +248,7 @@ class SSRS():
 		
 		log.error(param_xml)
 		try:
+			param_xml = byte_str(param_xml)
 			setparam = self.ExecutionClient.service.SetExecutionParameters(__inject={'msg': param_xml})
 		except Exception as e:
 			msg = "Could not Send Parameters: %s" % e.args
@@ -264,6 +266,7 @@ class SSRS():
 		
 		# Render the report by its ExecutionID
 		try:
+			xml = byte_str(xml)
 			result = self.ExecutionClient.service.Render(__inject={'msg': xml})
 		except Exception as e:
 			msg = "Could not Render the Report: %s" % e.args


### PR DESCRIPTION
hi Andrew, as discussed in emails, I propose adding an explicit conversion to "byte string" before passing the parameter in to ensure suds-py3 works properly.

I've tested the change with Python 3.8.5 x64 on Windows 10.  Please can you test it on your Linux distro and let me know if there's any issue, thanks!