### PR TITLE
Escape XML characters used in report parameters

### DIFF
--- a/SSRS/__init__.py
+++ b/SSRS/__init__.py
@@ -16,6 +16,7 @@ import uuid
 import sys
 import os
 from _ast import Load
+from xml.sax.saxutils import escape
 
 class SSRS():
 	'''
@@ -241,7 +242,7 @@ class SSRS():
 			   <rep:Name>%s</rep:Name>
 			   <rep:Value>%s</rep:Value>
 			</rep:ParameterValue>
-			''' % (k[0], k[1])
+			''' % (escape(k[0]), escape(k[1]))
 		
 		param_xml = schemas.xml_Execute_Report_Parameter  
 		param_xml = param_xml.format(LoadedReport.ExecutionID, params)


### PR DESCRIPTION
The RenderReport soap call breaks when passing in parameters with special XML characters (e.g. <, >, &, etc.), to solve this problem, we can escape XML characters using the built-in saxutils.  No impact to performance and it doesn't do anything if there's nothing to escape.

I feel it would be good to add this in, so users wouldn't have to do it themselves.